### PR TITLE
Add docker-compose file for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3"
+services:
+  db:
+    image: postgres:9.6
+    volumes:
+      - $HOME/postgresql/9.6/data:/var/lib/postgresql/data
+    ports:
+      - "5432"
+  web:
+    build: .
+    command: "bundle exec rails s -p 21004 -b 0.0.0.0"
+    ports:
+      - "21004:21004"
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_USER: postgres
+    volumes:
+      - .:/usr/src/myapp
+      - bundle-volume:/usr/src/bundler
+    links:
+      - db
+volumes:
+  bundle-volume:
+
+networks:
+  default:
+    external:
+      name: ezcater-development-network


### PR DESCRIPTION
this is pretty standard. i left out pulling env from a local `.env` file. i dont think we'll need it since `SCHEMA_REGISTRY_PASSWORD` and some of the other env vars have defaults for dev environment. i also added it to the network we're using for other apps. lastly, i gave it port 21004 since it was next in line but wasnt sure if we wanted to assign it something else 