### PR TITLE
Deploy to both production and production compatibility at the same time

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       rack-accept
       virtus (>= 1.0.0)
     hashie (3.5.4)
-    heroku_rails_deploy (0.4.3)
+    heroku_rails_deploy (0.4.5)
       private_attr
       rails
     i18n (0.9.1)

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ Accept: application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+j
 
 ## Deployment
 
+Run `bin/deploy --environment <staging|production>` to deploy the application staging or production.
+The app will be deployed to both the intended environment and the corresponding compatibility environment.
+
 Salsify hosts a public instance of this application at
 [avro-schema-registry.salsify.com](https://avro-schema-registry.salsify.com) that
 anyone can experiment with, just please don't rely on it for production!

--- a/config/heroku.yml
+++ b/config/heroku.yml
@@ -1,4 +1,5 @@
 ---
-production: schema-registry-prod
-staging: schema-registry-staging
-compatibility: schema-registry-compatibility
+production: ezcater-asr-production
+production-compat: ezcater-asr-compat-production
+staging: ezcater-asr-staging
+staging-compat: ezcater-asr-compat-staging

--- a/lib/dual_heroku_rails_deploy.rb
+++ b/lib/dual_heroku_rails_deploy.rb
@@ -7,6 +7,10 @@ module DualHerokuRailsDeploy
     deploy = HerokuRailsDeploy::Deployer.new(config_file, args)
     deploy.run
 
-    HerokuRailsDefploy::Deployer.new(config_file, %w(-e compatibility)).run
+    if deploy.production?
+      HerokuRailsDeploy::Deployer.new(config_file, %w(-e production-compat)).run
+    else
+      HerokuRailsDeploy::Deployer.new(config_file,  %w(-e staging-compat)).run
+    end
   end
 end

--- a/lib/dual_heroku_rails_deploy.rb
+++ b/lib/dual_heroku_rails_deploy.rb
@@ -7,8 +7,6 @@ module DualHerokuRailsDeploy
     deploy = HerokuRailsDeploy::Deployer.new(config_file, args)
     deploy.run
 
-    if deploy.production?
-      HerokuRailsDeploy::Deployer.new(config_file, %w(-e compatibility)).run
-    end
+    HerokuRailsDefploy::Deployer.new(config_file, %w(-e compatibility)).run
   end
 end

--- a/lib/dual_heroku_rails_deploy.rb
+++ b/lib/dual_heroku_rails_deploy.rb
@@ -10,7 +10,7 @@ module DualHerokuRailsDeploy
     if deploy.production?
       HerokuRailsDeploy::Deployer.new(config_file, %w(-e production-compat)).run
     else
-      HerokuRailsDeploy::Deployer.new(config_file,  %w(-e staging-compat)).run
+      HerokuRailsDeploy::Deployer.new(config_file, %w(-e staging-compat)).run
     end
   end
 end


### PR DESCRIPTION
## What did we change?
Enabled dual deploys (to production and production-compatibility) for the avro schema registry.
Bumped up version of heroku_rails_deploy

## Why are we doing this?
So we don't need to remember to deploy to two apps when releasing changes to the main production app.

## How was it tested?
- [ ] Specs
- [ ] Locally
- [x] Staging
- [ ] Migrations Reviewed (Zero Downtime)
