### PR TITLE
Update slack room for build notifications

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,5 +1,5 @@
 name: avro-schema-registry
-slack: pb-s-sparkle-motion
+slack: pb-s-service-car
 
 staging:
   environment:


### PR DESCRIPTION
## What did we change?
`pb-s-sparkle-motion` -> `pb-s-service-car`

## Why are we doing this?
since `pb-s-sparkle-motion` isnt a room anymore and service car owns these services

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
- [ ] Migrations Reviewed (Zero Downtime)
