### PR TITLE
Change puma workers to 1 and bump skyline replicas

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,17 +1,41 @@
-# Simple configuration based on
-# https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
+# frozen_string_literal: true
 
-workers Integer(ENV['WEB_WORKER_PROCESSES'] || 2)
-threads_count = Integer(ENV['MAX_WEB_THREADS'] || 5)
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+threads_count = ENV.fetch('MAX_WEB_THREADS') { 5 }
 threads threads_count, threads_count
 
-preload_app!
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch('PORT') { 21000 }
 
-rackup      DefaultRackup
-port        ENV['PORT']     || 21000
-environment ENV['RACK_ENV'] || 'development'
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch('RAILS_ENV') { 'development' }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked webserver processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 1 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+# preload_app!
 
 on_worker_boot do
   # Worker specific setup for Rails 4.1+
   ActiveRecord::Base.establish_connection
 end
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart

--- a/service.yml
+++ b/service.yml
@@ -14,7 +14,7 @@ deployables:
     type: web
     port: 3000
     command: "bundle exec rails server -p 3000 -b 0.0.0.0"
-    replicas: 2
+    replicas: 3
     health_check_path: "/health_check"
     staging:
       host: "asr.staging-ezcater.com"


### PR DESCRIPTION
from patrick:
>Heads up that y’all probably want to change any services running with 2 puma workers to just 1, and bump replicas up appropriately. We recently found out that kube only keeps track of the initial container a pod runs, so the kernel can OOM kill any other workers without kube realizing it