### PR TITLE
Bind web container to 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - schema-registry-db
     command: "bin/start"
     ports:
-      - "21004:21004"
+      - "127.0.0.1:21004:21004"
     environment:
       POSTGRES_HOST: schema-registry-db
       POSTGRES_USER: postgres


### PR DESCRIPTION
## What did we change?
In `docker-compose.yml`, change the web container to bind to the `127.0.0.1` network interface.

## Why are we doing this?
We noticed awhile ago that the rails-template was creating `docker-compose.yml` files that were binding containers to all network interfaces, which exposes the container to whatever network the machine is connected to. This changes the port specification so that the container binds its port to 127.0.0.1.