### PR TITLE
Update Postgres volume directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: avroschemaregistry_schema-registry-db_1
     image: postgres:10.10
     volumes:
-      - $HOME/postgresql/9.6/data/schema-registry:/var/lib/postgresql/data:delegated
+      - $HOME/postgresql/10.10/data/schema-registry:/var/lib/postgresql/data:delegated
 
   schema-registry-web:
     container_name: avroschemaregistry_schema-registry-web_1


### PR DESCRIPTION
We're changing the Posgtres data directory to reflect image version, otherwise running `docker/start` produces `The data directory was initialized by PostgreSQL version 9.6, which is not compatible with this version 10.10 (Debian 10.10-1.pgdg90+1).`