### PR TITLE
Update ezcater_apm and ddtrace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     childprocess (4.0.0)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
-    ddtrace (0.38.0)
+    ddtrace (0.41.0)
       msgpack
     diff-lcs (1.4.4)
     docile (1.3.2)
@@ -108,9 +108,9 @@ GEM
       dry-logic (~> 1.0, >= 1.0.2)
     erubi (1.9.0)
     excon (0.76.0)
-    ezcater_apm (0.10.0)
+    ezcater_apm (0.11.1)
       activesupport (>= 5.2, < 6.1)
-      ddtrace (>= 0.38.0)
+      ddtrace (>= 0.39.0)
       metrics_reporter
     ezcater_docker_shared (1.1.1)
       rails


### PR DESCRIPTION
I noticed this service is a version behind on ezcater_apm, and a few more on its ddtrace dependency.